### PR TITLE
fix: delegated body wheel listener for volume on audio panel

### DIFF
--- a/2.js
+++ b/2.js
@@ -2450,6 +2450,7 @@ dl=()=>{				D&&log('DOMContentLoaded');
 	h.replaceChild=(e,n)=>{e.rel=='shortcut icon'?fav(e.href):f(e,n)};w.setFavIcon=fav;fav();forEach('link[rel*="icon"]',e=>e!=w.icoNode&&e.remove());
 	if(gec('VKVideoLogo'))gec('VKVideoLogo').removeAttribute('accesskey');
 	if(w.top_audio_player||w.web_spa_top_audio_player)['mouseenter','keydown','wheel'].forEach((e,i)=>(w.top_audio_player||w.web_spa_top_audio_player).addEventListener(e,i?st.k:fe,{passive:false}));
+	b.addEventListener('wheel',e=>{if(w.ap&&e.deltaY&&e.target.closest('#web_spa_top_audio_player,#top_audio_player,.top_audio_player,[class*="TopAudioPlayer"],[class*="audio_page_player"],.audio_page_layout')&&!e.target.closest('.cp_eq,.cp_ep,[type="range"]')){ap.set_volume(e);End(e)}},{passive:false});
 	if((w.top_audio_btn_group||w.web_spa_top_audio_player)&&!w.top_audio_play){let a=ce();a.id='top_audio_play';a.addEventListener('click',e=>ap.playPlaylist(vk.id,-1,0,0,e.shiftKey));(w.top_audio_btn_group||w.web_spa_top_audio_player).after(a)};
 	if(wl.e)wl()
 },


### PR DESCRIPTION
- Add document.body wheel listener as universal fallback for volume control
- Matches any audio player area (#web_spa_top_audio_player, TopAudioPlayer, etc.)
- Excludes EQ controls and range inputs to avoid conflicts
- Works regardless of visualizer mode or when player appears in DOM