### PR TITLE
fix: wheel volume only on player bar, not entire music page

### DIFF
--- a/2.js
+++ b/2.js
@@ -2450,7 +2450,7 @@ dl=()=>{				D&&log('DOMContentLoaded');
 	h.replaceChild=(e,n)=>{e.rel=='shortcut icon'?fav(e.href):f(e,n)};w.setFavIcon=fav;fav();forEach('link[rel*="icon"]',e=>e!=w.icoNode&&e.remove());
 	if(gec('VKVideoLogo'))gec('VKVideoLogo').removeAttribute('accesskey');
 	if(w.top_audio_player||w.web_spa_top_audio_player)['mouseenter','keydown','wheel'].forEach((e,i)=>(w.top_audio_player||w.web_spa_top_audio_player).addEventListener(e,i?st.k:fe,{passive:false}));
-	b.addEventListener('wheel',e=>{if(w.ap&&e.deltaY&&e.target.closest('#web_spa_top_audio_player,#top_audio_player,.top_audio_player,[class*="TopAudioPlayer"],[class*="audio_page_player"],.audio_page_layout')&&!e.target.closest('.cp_eq,.cp_ep,[type="range"]')){ap.set_volume(e);End(e)}},{passive:false});
+	b.addEventListener('wheel',e=>{if(w.ap&&e.deltaY&&e.target.closest('#web_spa_top_audio_player,#top_audio_player,.top_audio_player,[class*="TopAudioPlayer"],[class*="audio_page_player__"]')&&!e.target.closest('.cp_eq,.cp_ep,[type="range"]')){ap.set_volume(e);End(e)}},{passive:false});
 	if((w.top_audio_btn_group||w.web_spa_top_audio_player)&&!w.top_audio_play){let a=ce();a.id='top_audio_play';a.addEventListener('click',e=>ap.playPlaylist(vk.id,-1,0,0,e.shiftKey));(w.top_audio_btn_group||w.web_spa_top_audio_player).after(a)};
 	if(wl.e)wl()
 },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to VK Styles Clean will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [2.0.5.2] - 2026-02-22
+
+### Fixed
+- Колёсико мыши больше не меняет громкость на всей странице музыки — только на панели плеера
+
 ## [2.0.5.1] - 2026-02-21
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "2.0.5.1",
+	"version": "2.0.5.2",
 	"name": "__MSG_name__",
 	"short_name": "VK Styles Clean",
 	"description": "__MSG_description__",


### PR DESCRIPTION
Remove .audio_page_layout from body wheel selector — it matched the entire music page, causing scroll-anywhere volume changes on /audio. Narrowed to [class*='audio_page_player__'] for player-specific elements.

Bump version to 2.0.5.2